### PR TITLE
Removing keyof function from object prototype

### DIFF
--- a/lib/correios.js
+++ b/lib/correios.js
@@ -10,7 +10,7 @@ String.prototype.clean = function() {
 
 
 // search for object key, passing it's value
-Object.prototype.keyOf = function( object, value ){
+keyOf = function( object, value ){
 	for (var key in object){
 		if (hasOwnProperty.call(object, key) && object[key] === value) return key;
 	}
@@ -287,7 +287,7 @@ var correios = module.exports = {
 
 			return callback( null, {
 
-				serviceType: 			Object.keyOf(CorreiosOptions.deliveryTypes, parseInt(data.Codigo)),
+				serviceType: 			keyOf(CorreiosOptions.deliveryTypes, parseInt(data.Codigo)),
 				estimatedDelivery: 	parseInt(data.PrazoEntrega),
 				GrandTotal: 			parseFloat(data.Valor.replace(/,/g, '.')),
 				handDeliveryPrice: 		parseFloat(data.ValorMaoPropria.replace(/,/g, '.')),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	
 	"keywords": [ "correios", "track", "muamba", "sedex", "pac", "calculo" ],
 	
-	"version": "0.0.2",
+	"version": "0.0.3",
 
 	"author": "Felipe K. De Boni <pkz.dev@gmail.com>",
 	


### PR DESCRIPTION
The function was causing problem on several tests (object comparison, etc), and there was no reason it had to be on the prototype, as it was not called as an instance function.
BTW, thanks for the work, saved me quite some time.
Cheers.
